### PR TITLE
Fixed RaidWaringFrameMixin typo

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -52,7 +52,7 @@ globals = {
 	"C_TooltipInfo",
 	"C_GameRules",
 	"floor",
-	"RaidWaringFrameMixin",
+	"RaidWarningFrameMixin",
 	"LE_EXPANSION_CLASSIC",
 	"LE_EXPANSION_BURNING_CRUSADE",
 	"LE_EXPANSION_WRATH_OF_THE_LICH_KING",

--- a/ClassicLootManager/Modules/Global/GlobalChatMessageHandlers.lua
+++ b/ClassicLootManager/Modules/Global/GlobalChatMessageHandlers.lua
@@ -44,7 +44,7 @@ local function mainlineRaidWarningFrameOnEvent(self, event, message)
         message = subsituteWithIcon(message)
     end
 
-    RaidWaringFrameMixin.OnEvent(self, event, message)
+    RaidWarningFrameMixin.OnEvent(self, event, message)
 end
 
 local raidWarningFrameOnEvent = classicRaidWarningFrameOnEvent


### PR DESCRIPTION
Fixed typo from https://github.com/CoreLootManager/CoreLootManager/pull/664